### PR TITLE
Split game settings into submenus, enhance setting GUI

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/PGM.java
+++ b/PGM/src/main/java/tc/oc/pgm/PGM.java
@@ -38,6 +38,7 @@ import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchLoader;
 import tc.oc.pgm.match.MatchManager;
 import tc.oc.pgm.match.MatchPlayer;
+import tc.oc.pgm.menu.gui.SettingMenuHelper;
 import tc.oc.pgm.pollablemaps.PollableMaps;
 import tc.oc.pgm.polls.PollListener;
 import tc.oc.pgm.polls.PollManager;
@@ -173,6 +174,7 @@ public final class PGM extends JavaPlugin {
         navigatorInterface.setOpenButtonSlot(Slot.Hotbar.forPosition(7));
 
         new MainTokenButton();
+        SettingMenuHelper.initializeSettings();
     }
 
     @Override

--- a/PGM/src/main/java/tc/oc/pgm/menu/gui/MainMenuInterface.java
+++ b/PGM/src/main/java/tc/oc/pgm/menu/gui/MainMenuInterface.java
@@ -56,7 +56,7 @@ public class MainMenuInterface extends ChestInterface {
                 , 15) {
             @Override
             public void function(Player player) {
-                player.openInventory(new SettingsInterface(player).getInventory());
+                player.openInventory(new SettingsTypeInterface(player).getInventory());
             }
         });
 

--- a/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingMenuHelper.java
+++ b/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingMenuHelper.java
@@ -1,0 +1,49 @@
+package tc.oc.pgm.menu.gui;
+
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.bukkit.PlayerSettings;
+import tc.oc.commons.bukkit.broadcast.BroadcastSettings;
+import tc.oc.commons.bukkit.punishment.PunishmentMessageSetting;
+import tc.oc.commons.bukkit.users.JoinMessageSetting;
+import tc.oc.commons.bukkit.whisper.WhisperSettings;
+import tc.oc.pgm.damage.DamageSettings;
+import tc.oc.pgm.death.DeathMessageSetting;
+import tc.oc.pgm.picker.PickerSettings;
+import tc.oc.pgm.playerstats.StatSettings;
+import tc.oc.pgm.settings.ObserverSetting;
+import tc.oc.pgm.settings.Settings;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SettingMenuHelper {
+
+    private static Map<Setting, SettingType> settings = new HashMap<>();
+
+    public static void initializeSettings() {
+        Setting[] chat = {DeathMessageSetting.get(), JoinMessageSetting.get(), WhisperSettings.receive(), PunishmentMessageSetting.get(), BroadcastSettings.TIPS};
+        Setting[] gameplay = {DamageSettings.ATTACK_SPEEDOMETER, DamageSettings.DAMAGE_NUMBERS, DamageSettings.KNOCKBACK_PARTICLES, Settings.BLOOD};
+        Setting[] misc = {ObserverSetting.get(), PickerSettings.PICKER, Settings.SOUNDS, WhisperSettings.sound(), StatSettings.STATS};
+
+        for (Setting s : chat) { settings.put(s,SettingType.CHAT); }
+        for (Setting s : gameplay) { settings.put(s,SettingType.GAMEPLAY); }
+        for (Setting s : misc) { settings.put(s,SettingType.MISC); }
+    }
+
+    public static List<Setting> getAllOfType (SettingType settingType) {
+        return PlayerSettings.getRegistry().getSettings().stream().filter(setting -> getSettingType(setting) == settingType).collect(Collectors.toList());
+    }
+
+    private static SettingType getSettingType(Setting setting) {
+        if (settings.get(setting) != null) {
+            return settings.get(setting);
+        }
+        return SettingType.MISC;
+    }
+
+    public enum SettingType {
+        CHAT,GAMEPLAY,MISC
+    }
+}

--- a/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingsInterface.java
+++ b/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingsInterface.java
@@ -31,20 +31,19 @@ import java.util.*;
 
 public class SettingsInterface extends SinglePageInterface {
 
-    public SettingsInterface(Player player) {
-        super(player, new ArrayList<>(), 54, "Settings");
+    SettingMenuHelper.SettingType settingType;
+
+    public SettingsInterface(Player player, SettingMenuHelper.SettingType settingType) {
+        super(player, new ArrayList<>(), 54, settingType.toString() + "Settings");
+        this.settingType = settingType;
         update();
     }
 
     @Override
     public void setButtons() {
         List<Button> buttons = new ArrayList<>();
-        List<Setting> settings = Lists.newArrayList(PlayerSettings.getRegistry().getSettings());
-        Collections.sort(settings, new Comparator<Setting>() {
-            public int compare(Setting s1, Setting s2) {
-                return s1.getName().compareTo(s2.getName());
-            }
-        });
+        List<Setting> settings = SettingMenuHelper.getAllOfType(settingType);
+        Collections.sort(settings, (s1, s2) -> s1.getName().compareTo(s2.getName()));
 
         for(Iterator<Setting> it = settings.iterator(); it.hasNext(); ) {
             Setting setting = it.next();

--- a/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingsTypeInterface.java
+++ b/PGM/src/main/java/tc/oc/pgm/menu/gui/SettingsTypeInterface.java
@@ -1,0 +1,94 @@
+package tc.oc.pgm.menu.gui;
+
+import com.google.api.client.util.Lists;
+import me.anxuiz.settings.Setting;
+import me.anxuiz.settings.SettingManager;
+import me.anxuiz.settings.Toggleable;
+import me.anxuiz.settings.bukkit.PlayerSettings;
+import me.anxuiz.settings.bukkit.plugin.Permissions;
+import me.anxuiz.settings.types.BooleanType;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import tc.oc.commons.bukkit.gui.buttons.Button;
+import tc.oc.commons.bukkit.gui.buttons.empty.EmptyButton;
+import tc.oc.commons.bukkit.gui.interfaces.SinglePageInterface;
+import tc.oc.commons.bukkit.tokens.TokenUtil;
+import tc.oc.commons.bukkit.util.Constants;
+import tc.oc.commons.bukkit.util.ItemCreator;
+import tc.oc.pgm.PGM;
+import tc.oc.pgm.PGMTranslations;
+import tc.oc.pgm.mutation.Mutation;
+import tc.oc.pgm.mutation.MutationMatchModule;
+import tc.oc.pgm.mutation.command.MutationCommands;
+import tc.oc.pgm.picker.PickerSettings;
+import tc.oc.pgm.tokens.gui.MainTokenMenu;
+import tc.oc.pgm.tokens.gui.MutationConfirmInterface;
+
+import java.util.*;
+
+public class SettingsTypeInterface extends SinglePageInterface {
+
+    public SettingsTypeInterface(Player player) {
+        super(player, new ArrayList<>(), 27, "Setting Types");
+        update();
+    }
+
+    @Override
+    public void setButtons() {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(new Button(
+                new ItemCreator(Material.BOOK_AND_QUILL)
+                        .setName(Constants.PREFIX + "Chat")
+                , 11) {
+            @Override
+            public void function(Player player) {
+                player.openInventory(new SettingsInterface(player, SettingMenuHelper.SettingType.CHAT).getInventory());
+            }
+        });
+        buttons.add(new Button(
+                new ItemCreator(Material.DIAMOND_SWORD)
+                        .setName(Constants.PREFIX + "Gameplay")
+                , 13) {
+            @Override
+            public void function(Player player) {
+                player.openInventory(new SettingsInterface(player, SettingMenuHelper.SettingType.GAMEPLAY).getInventory());
+            }
+        });
+        buttons.add(new Button(
+                new ItemCreator(Material.SLIME_BALL)
+                        .setName(Constants.PREFIX + "Miscellaneous")
+                , 15) {
+            @Override
+            public void function(Player player) {
+                player.openInventory(new SettingsInterface(player, SettingMenuHelper.SettingType.MISC).getInventory());
+            }
+        });
+
+        setButtons(buttons);
+    }
+
+
+    @Override
+    public void setDefaultButtons() {
+        defaultButtons.clear();
+        defaultButtons.add(new Button(new ItemCreator(Material.WOOL)
+                .setData(14)
+                .setName(ChatColor.GREEN + "Go Back"), 22) {
+            @Override
+            public void function(Player player) {
+                player.openInventory(new MainMenuInterface(player).getInventory());
+            }
+        });
+        for (Integer integer : new Integer[]{
+                0,  1,  2,  3,  4,  5,  6,  7,  8,
+                9, 10,     12,     14,     16,  17,
+                18,19, 20, 21,     23, 24, 25,  26}) {
+            EmptyButton button = new EmptyButton(integer);
+            defaultButtons.add(button);
+        }
+    }
+
+}


### PR DESCRIPTION
Splits settings into 3 submenus according to type:

| Chat                | Gameplay              | Miscellaneous |
|---------------------|-----------------------|---------------|
| Death Messages      | Attack Speed o' Meter | Observers     |
| Join Messages       | Blood :hocho:                 | Picker        |
| Private Messages    | Damage Numbers        | Sounds        |
| Punishment Messages | Knockback Particles   | Stats         |
| Tips                |                       |               |

And a few more I could be missing. Any other setting is classified as Miscellaneous if not added to the other two lists @ `SettingMenuHelper#initializeSettings`

:spaghetti: :sparkles: 