### PR TITLE
Allow build organizations to be defined in XML 

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -33,6 +33,7 @@ import tc.oc.pgm.PGM;
 import tc.oc.pgm.PGMTranslations;
 import tc.oc.pgm.ffa.FreeForAllModule;
 import tc.oc.pgm.map.Contributor;
+import tc.oc.pgm.map.Organization;
 import tc.oc.pgm.map.MapInfo;
 import tc.oc.pgm.map.PGMMap;
 import tc.oc.pgm.modules.InfoModule;
@@ -141,6 +142,13 @@ public class MapCommands {
             audience.sendMessage(mapInfoLabel("command.map.mapInfo.contributors"));
             for(Contributor contributor : contributors) {
                 audience.sendMessage(new Component("  ").extra(formatContribution(contributor)));
+            }
+        }
+        List<Organization> organizations = mapInfo.getNamedOrganizations();
+        if(!organizations.isEmpty()) {
+            audience.sendMessage(mapInfoLabel("command.map.mapInfo.organizations"));
+            for(Contributor organization : organizations) {
+                audience.sendMessage(new Component("  ").extra(formatContribution(organization)));
             }
         }
 

--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -144,20 +144,6 @@ public class MapCommands {
             }
         }
 
-        List<Organization> organizations = mapInfo.getNamedOrganizations();
-        if(organizations.size() == 1) {
-            audience.sendMessage(new Component(
-                    mapInfoLabel("command.map.mapInfo.organizationSingular"),
-                    formatContribution(organizations.get(0))
-            ));
-        } else if(!organizations.isEmpty()) {
-            audience.sendMessage(mapInfoLabel("command.map.mapInfo.organizationPlural"));
-            for(Contributor organization : organizations) {
-                audience.sendMessage(new Component("  ").extra(formatContribution(organization)));
-            }
-        }
-
-
         if(mapInfo.rules.size() > 0) {
             audience.sendMessage(mapInfoLabel("command.map.mapInfo.rules"));
 

--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -144,6 +144,20 @@ public class MapCommands {
             }
         }
 
+        List<Organization> organizations = mapInfo.getNamedOrganizations();
+        if(organizations.size() == 1) {
+            audience.sendMessage(new Component(
+                    mapInfoLabel("command.map.mapInfo.organizationSingular"),
+                    formatContribution(organizations.get(0))
+            ));
+        } else if(!organizations.isEmpty()) {
+            audience.sendMessage(mapInfoLabel("command.map.mapInfo.organizationPlural"));
+            for(Contributor organization : organizations) {
+                audience.sendMessage(new Component("  ").extra(formatContribution(organization)));
+            }
+        }
+
+
         if(mapInfo.rules.size() > 0) {
             audience.sendMessage(mapInfoLabel("command.map.mapInfo.rules"));
 

--- a/PGM/src/main/java/tc/oc/pgm/map/MapInfo.java
+++ b/PGM/src/main/java/tc/oc/pgm/map/MapInfo.java
@@ -51,6 +51,9 @@ public class MapInfo implements Comparable<MapInfo> {
     /** List of contributors and their contributions. */
     public final List<Contributor> contributors;
 
+    /** List of organizations and their contributions. */
+    public final List<Organization> organizations;
+
     /** List of rules for this map. */
     public final List<String> rules;
 
@@ -152,6 +155,10 @@ public class MapInfo implements Comparable<MapInfo> {
 
     public List<Contributor> getNamedContributors() {
         return Contributor.filterNamed(this.contributors);
+    }
+
+    public List<Contributor> getNamedOrganizations() {
+        return Organization.filterNamed(this.organizations);
     }
 
     public Stream<Contributor> allContributors() {

--- a/PGM/src/main/java/tc/oc/pgm/map/Organization.java
+++ b/PGM/src/main/java/tc/oc/pgm/map/Organization.java
@@ -1,0 +1,105 @@
+package tc.oc.pgm.map;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import tc.oc.api.docs.virtual.UserDoc;
+import tc.oc.commons.bukkit.chat.NameStyle;
+import tc.oc.commons.bukkit.chat.Named;
+import tc.oc.commons.bukkit.chat.PlayerComponent;
+import tc.oc.commons.bukkit.nick.Identity;
+import tc.oc.commons.bukkit.nick.IdentityProvider;
+import tc.oc.commons.core.chat.Component;
+import tc.oc.pgm.PGM;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * An organization to a {@link PGMMap}. Can have either or both of a UUID
+ * and arbitrary String name. If a UUID is present, it is used to lookup
+ * a username when the map loads. The fallback name is only used if the
+ * lookup fails, or no UUID is provided (this could be used to credit
+ * somebody without a Minecraft account, like mom or Jesus).
+ */
+public class Organization implements Named {
+    protected final @Nullable UUID uuid;
+    protected final @Nullable String fallbackName;
+    protected final @Nullable String organization;
+
+    protected @Nullable UserDoc.Identity user;
+
+    /** Creates an organization with a name and a contribution. */
+    public Organization(@Nullable UUID uuid, @Nullable String fallbackName, @Nullable String contribution) {
+        this.uuid = uuid;
+        this.fallbackName = fallbackName;
+        this.contribution = contribution;
+
+        checkArgument(uuid != null || fallbackName != null);
+    }
+
+    @Override
+    public String toString() {
+        return this.getName();
+    }
+
+    public @Nullable UUID getUuid() {
+        return uuid;
+    }
+
+    /** Gets the name of this organization. */
+    public @Nullable String getName() {
+        return user != null ? user.username() : this.fallbackName;
+    }
+
+    public @Nullable UserDoc.Identity getUser() {
+        return user;
+    }
+
+    public void setUser(UserDoc.Identity user) {
+        this.user = user;
+    }
+
+    public @Nullable Identity getIdentity() {
+        return user == null ? null : PGM.get().injector().getInstance(IdentityProvider.class).createIdentity(getUser(), null);
+    }
+
+    @Override
+    public BaseComponent getStyledName(NameStyle style) {
+        return user != null ? new PlayerComponent(getIdentity(), style)
+                            : new Component(fallbackName);
+    }
+
+    /**
+     * @return true only if a username is available
+     */
+    public boolean hasName() {
+        return this.user != null || this.fallbackName != null;
+    }
+
+    public boolean needsLookup() {
+        return this.uuid != null && this.user == null;
+    }
+
+    /** Indicates whether or not this organization has a specific organization. */
+    public boolean hasContribution() {
+        return this.contribution != null;
+    }
+
+    /** Gets this organization's contribution or null if none exists. */
+    public @Nullable String getContribution() {
+        return this.contribution;
+    }
+
+    public static List<Organization> filterNamed(List<Organization> organizations) {
+        List<Organization> resolved = new ArrayList<>();
+        for(Organization organization : organizations) {
+            if(organization.hasName()) {
+                resolved.add(organization);
+            }
+        }
+        return resolved;
+    }
+}


### PR DESCRIPTION
I would like this for this to be a thing

```
   <organizations>
      <organization contribution="Lobby Framework"/> <!-- Orange Sunglasses-->
      <organization contribution="Lobby Framework"/> <!-- Hypixel-->
   </organizations>
```

If not then close me because this is my first time working with Project Ares and I don't know how to code

Also ignore the first two commits, just squash and make the "Allow build organizations to be defined in XML" the only one if it is able to be merged