### PR TITLE
See all touched objectives when round ends.

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -176,8 +176,7 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
         return team != null &&
                !isCompleted(team) &&
                hasTouched(team) &&
-               (team == viewer || showEnemyTouches() || viewer.isObservingType() 
-                   || getMatch().isFinished());
+               (team == viewer || showEnemyTouches() || viewer.isObservingType() || getMatch().isFinished());
     }
 
     protected void sendTouchMessage(@Nullable ParticipantState toucher, boolean includeToucher) {

--- a/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -176,7 +176,8 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
         return team != null &&
                !isCompleted(team) &&
                hasTouched(team) &&
-               (team == viewer || showEnemyTouches() || viewer.isObservingType());
+               (team == viewer || showEnemyTouches() || viewer.isObservingType() 
+                   || getMatch().needMatchModule(VictoryMatchModule.class).checkMatchEnd());
     }
 
     protected void sendTouchMessage(@Nullable ParticipantState toucher, boolean includeToucher) {

--- a/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/PGM/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -177,7 +177,7 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
                !isCompleted(team) &&
                hasTouched(team) &&
                (team == viewer || showEnemyTouches() || viewer.isObservingType() 
-                   || getMatch().needMatchModule(VictoryMatchModule.class).checkMatchEnd());
+                   || getMatch().isFinished());
     }
 
     protected void sendTouchMessage(@Nullable ParticipantState toucher, boolean includeToucher) {


### PR DESCRIPTION
Quality of life feature, to otherwise accomplish this you have to join spectator mode after the round ends, which seems excessive because at that point everyone essentially is a spectator with its features.

I don't have the knowledge required to get a server working, so I am not able to test this by myself.