### PR TITLE
fixes /stats exposing target nickname

### DIFF
--- a/Commons/bukkit/src/main/java/tc/oc/commons/bukkit/stats/StatsCommands.java
+++ b/Commons/bukkit/src/main/java/tc/oc/commons/bukkit/stats/StatsCommands.java
@@ -52,7 +52,7 @@ public class StatsCommands implements Commands {
                     Audience audience = audiences.get(sender);
 
                     audience.sendMessage(new HeaderComponent(new Component(ChatColor.AQUA)
-                            .translate("stats.list", new PlayerComponent(identityProvider.createIdentity(result)))));
+                            .translate("stats.list", new PlayerComponent(identityProvider.createIdentity(result.user, result.user.nickname())))));
                     audience.sendMessage(new Component(ChatColor.AQUA)
                             .translate("stats.kills", new Component(String.format("%,d", (int)(double)stats.get("kills")), ChatColor.BLUE)));
                     audience.sendMessage(new Component(ChatColor.AQUA)


### PR DESCRIPTION
because this happens: https://gyazo.com/fbe66161a6284b75d3d41ec969c055cf