### PR TITLE
Prevent entities from being created with bomber mutation

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/targetable/BomberMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/targetable/BomberMutation.java
@@ -36,6 +36,7 @@ public class BomberMutation extends EntityMutation<TNTPrimed> implements TargetM
                 TNTPrimed tnt = spawn(location, TNTPrimed.class);
                 tnt.setGlowing(true);
                 tnt.setIsIncendiary(false);
+                tnt.setYield(0);
                 tnt.setFuseTicks(200);
                 tnt.setVelocity(
                         new Vector(


### PR DESCRIPTION
The bomber mutation shouldn't be any more laggy than necessary, and having entities scatter everywhere is a root cause of possible lag. By setting the blocks it yields to 0, it should stop any possible issues with entities lagging the server (since I didn't already see this property in the code)