### PR TITLE
RFC: Don't dynamically change next maps when a mutation is set.

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/mutation/MutationQueue.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/MutationQueue.java
@@ -34,6 +34,13 @@ public class MutationQueue {
     public ListenableFuture<Server> clear() {
         return force(Collections.emptyList());
     }
+    
+    public boolean isEmpty() {
+        return minecraftService
+            .getLocalServer()
+            .queued_mutations()
+            .isEmpty();
+    }
 
     public ListenableFuture<Server> removeAll(final Collection<Mutation> mutations) {
         Collection<Mutation> removed = mutations();

--- a/PGM/src/main/java/tc/oc/pgm/mutation/MutationQueue.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/MutationQueue.java
@@ -36,10 +36,7 @@ public class MutationQueue {
     }
     
     public boolean isEmpty() {
-        return minecraftService
-            .getLocalServer()
-            .queued_mutations()
-            .isEmpty();
+        return minecraftService.getLocalServer().queued_mutations().isEmpty();
     }
 
     public ListenableFuture<Server> removeAll(final Collection<Mutation> mutations) {

--- a/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
@@ -40,6 +40,9 @@ public class DynamicRotationListener implements PluginFacet, Listener {
 
         // Ignore if dynamic rotations are disabled or if there is only one rotation available
         if (!config.getBoolean("dynamic", false) || rotationManager.getRotations().size() <= 1) return;
+        
+        // If a mutation was set for the next map, don't change it yet.
+        if (!MutationCommands.getInstance().getMutationQueue().isEmpty()) return;
 
         int playerCount = players.count() + Math.round(event.getMatch().getObservingPlayers().size() / 2);
 

--- a/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
@@ -17,6 +17,7 @@ import tc.oc.commons.core.logging.Loggers;
 import tc.oc.commons.core.plugin.PluginFacet;
 import tc.oc.pgm.PGM;
 import tc.oc.pgm.events.MatchEndEvent;
+import tc.oc.pgm.mutation.MutationQueue;
 
 import java.util.logging.Logger;
 
@@ -26,12 +27,14 @@ public class DynamicRotationListener implements PluginFacet, Listener {
     private final Audiences audiences;
     private final OnlinePlayers players;
     private final ConfigurationSection config;
+    private final MutationQueue mutationQueue;
 
-    @Inject DynamicRotationListener(Loggers loggers, Audiences audiences, OnlinePlayers players, Configuration config) {
+    @Inject DynamicRotationListener(Loggers loggers, Audiences audiences, OnlinePlayers players, Configuration config, MutationQueue mutationQueue) {
         this.logger = loggers.get(getClass());
         this.audiences = audiences;
         this.players = players;
         this.config = config.getConfigurationSection("rotation");
+        this.mutationQueue = mutationQueue;
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -42,7 +45,7 @@ public class DynamicRotationListener implements PluginFacet, Listener {
         if (!config.getBoolean("dynamic", false) || rotationManager.getRotations().size() <= 1) return;
         
         // If a mutation was set for the next map, don't change it yet.
-        if (!MutationCommands.getInstance().getMutationQueue().isEmpty()) return;
+        if (mutationQueue.isEmpty()) return;
 
         int playerCount = players.count() + Math.round(event.getMatch().getObservingPlayers().size() / 2);
 


### PR DESCRIPTION
Many many times have I set a mutation intending for it to be applied to the map revealed by `/mapnext`, until the dynamic rotation changer (based on player count) pulls the rug out and changes it to a different map, which the mutation(s) then get applied too.

By best example for why this is needed took place less than two weeks ago: I set the Projectile mutation for a TDM map, to get a little spice in the game.
The rotation changed due to more players coming on, and the map then changed to `Glina`, a long CTW map. 
The Projectile mutation on objective maps has an extreme tendency to cause stalemates, for a lucky shot can get players killed in just a handful of shots, regardless of armor.
Because of the mutation, the map stalemated for over _Ninety_ minutes, and a moderator had to come and stop it manually. In the process it drove away a good third of the server due to the boring gameplay.

That is why I believe this fix should be added.