### PR TITLE
Teleport observers to default spawnpoint instead of cancelling event

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/PGM/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -121,10 +121,8 @@ public class Observing extends State {
     public void onEvent(CoarsePlayerMoveEvent event) {
         // Don't let observers fall into the void
         if(event.getFrom().getY() >= VOID_HEIGHT && event.getTo().getY() < VOID_HEIGHT) {
-            event.setCancelled(true);
-            if(event.getPlayer().getAllowFlight()) {
-                event.getPlayer().setFlying(true);
-            }
+            match.player(event.getPlayer())
+                 .ifPresent(player -> player.getBukkit().teleport(smm.getDefaultSpawn().getSpawn(player)));
         }
     }
 }


### PR DESCRIPTION
title says everything