### PR TITLE
Remove XML link in mapinfo command, and refactor command classes

### DIFF
--- a/Commons/core/src/main/i18n/templates/pgm/PGMErrors.properties
+++ b/Commons/core/src/main/i18n/templates/pgm/PGMErrors.properties
@@ -41,6 +41,8 @@ command.gameplay.join.joinDenied = You are not allowed to join this match
 command.gameplay.join.notSupported = No loaded module supports joining
 command.gameplay.join.uneven = You cannot join because it would make the teams uneven
 
+command.rotation.reload.failed = There was an error reloading the rotation - check the server logs
+
 # {0} = user being forced
 command.team.force.exempt = {0} is exempt from being forced on to teams.
 
@@ -63,6 +65,11 @@ command.playerNotFound = No players matched query.
 command.multiplePlayersFound = More than one player found! Use @<name> for exact matching.
 command.confirmNotFound = Could not find an action to confirm.
 command.unknownError = An unknown error has occurred. Please refer to the server console.
+command.context = Command must be used in the context of a match
+
+# {0} = Type name
+# {1} = ID
+command.noFeature = No {0} with ID {1}
 
 gameplay.ffa.kickedForPremium = You were kicked from the match to make room for a premium player
 gameplay.kickedForPremium = You were kicked off {0} to make room for a premium player

--- a/Commons/core/src/main/i18n/templates/pgm/PGMMessages.properties
+++ b/Commons/core/src/main/i18n/templates/pgm/PGMMessages.properties
@@ -1,6 +1,11 @@
 # {0} = map title
 command.admin.set.success = Next map set to {0}
 
+command.admin.ppr.match-count-disabled = Automatic match count restart disabled
+# {0} = number of matches
+command.admin.ppr.restart-in-matches = Server will restart automatically in {0} matches
+command.admin.ppr.restart-after-match = Server will automatically restart after the current match
+
 # {0} = map title and version
 command.admin.mapreload.success = {0} successfully marked for reloading.
 command.admin.mapreload.successAll = All maps successfully marked for reloading.

--- a/PGM/src/main/java/tc/oc/pgm/PGM.java
+++ b/PGM/src/main/java/tc/oc/pgm/PGM.java
@@ -20,10 +20,7 @@ import tc.oc.inject.ProtectedBinder;
 import tc.oc.minecraft.logging.BetterRaven;
 import tc.oc.pgm.antigrief.CraftingProtect;
 import tc.oc.pgm.channels.ChannelCommands;
-import tc.oc.pgm.commands.MapCommands;
 import tc.oc.pgm.commands.PollCommands;
-import tc.oc.pgm.commands.RotationControlCommands;
-import tc.oc.pgm.commands.RotationEditCommands;
 import tc.oc.pgm.events.ConfigLoadEvent;
 import tc.oc.pgm.ffa.FreeForAllCommands;
 import tc.oc.pgm.fireworks.ObjectivesFireworkListener;
@@ -194,11 +191,8 @@ public final class PGM extends JavaPlugin {
     }
 
     private void setupCommands() {
-        commands.register(MapCommands.class);
         commands.register(ChannelCommands.class);
         commands.register(PollCommands.class);
-        commands.register(RotationEditCommands.RotationEditParent.class);
-        commands.register(RotationControlCommands.RotationControlParent.class);
         commands.register(TimeLimitCommands.class);
         commands.register(MapRatingsCommands.class);
         commands.register(GoalCommands.class);

--- a/PGM/src/main/java/tc/oc/pgm/PGM.java
+++ b/PGM/src/main/java/tc/oc/pgm/PGM.java
@@ -6,8 +6,7 @@ import java.util.logging.Logger;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import tc.oc.api.util.Permissions;
@@ -15,6 +14,7 @@ import tc.oc.commons.bukkit.inject.BukkitPluginManifest;
 import tc.oc.commons.bukkit.inventory.Slot;
 import tc.oc.commons.bukkit.logging.MapdevLogger;
 import tc.oc.commons.bukkit.teleport.NavigatorInterface;
+import tc.oc.commons.core.chat.Component;
 import tc.oc.commons.core.commands.CommandRegistry;
 import tc.oc.inject.ProtectedBinder;
 import tc.oc.minecraft.logging.BetterRaven;
@@ -34,7 +34,6 @@ import tc.oc.pgm.mapratings.MapRatingsCommands;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchLoader;
 import tc.oc.pgm.match.MatchManager;
-import tc.oc.pgm.match.MatchPlayer;
 import tc.oc.pgm.menu.gui.SettingMenuHelper;
 import tc.oc.pgm.pollablemaps.PollableMaps;
 import tc.oc.pgm.polls.PollListener;
@@ -72,14 +71,6 @@ public final class PGM extends JavaPlugin {
 
     public static MatchManager getMatchManager() {
         return pgm == null ? null : pgm.matchManager;
-    }
-
-    public static MatchManager needMatchManager() {
-        MatchManager mm = getMatchManager();
-        if(mm == null) {
-            throw new IllegalStateException("PGMMatchManager is not available");
-        }
-        return mm;
     }
 
     public Logger getRootMapLogger() {
@@ -149,15 +140,9 @@ public final class PGM extends JavaPlugin {
 
         if(Config.Broadcast.periodic()) {
             // periodically notify people of what map they're playing
-            this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
-                @Override
-                public void run() {
-                    Match match = matchLoader.get().getCurrentMatch();
-                    Bukkit.getConsoleSender().sendMessage(ChatColor.DARK_PURPLE + PGMTranslations.get().t("broadcast.currentlyPlaying", Bukkit.getConsoleSender(), match.getMap().getInfo().getShortDescription(Bukkit.getConsoleSender()) + ChatColor.DARK_PURPLE));
-                    for (MatchPlayer player : match.getPlayers()) {
-                        player.sendMessage(ChatColor.DARK_PURPLE + PGMTranslations.t("broadcast.currentlyPlaying", player, match.getMap().getInfo().getShortDescription(player.getBukkit()) + ChatColor.DARK_PURPLE));
-                    }
-                }
+            this.getServer().getScheduler().scheduleSyncRepeatingTask(this, () -> {
+                Match match = matchLoader.get().getCurrentMatch();
+                match.sendMessage(new Component(ChatColor.DARK_PURPLE).translate("broadcast.currentlyPlaying", match.getMap().getInfo().getShortDescription()));
             }, 20, Config.Broadcast.frequency() * 20);
         }
 

--- a/PGM/src/main/java/tc/oc/pgm/PGMManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/PGMManifest.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm;
 
+import com.google.inject.Provides;
+import org.bukkit.plugin.Plugin;
 import tc.oc.commons.bukkit.flairs.FlairRenderer;
 import tc.oc.commons.bukkit.nick.UsernameRenderer;
 import tc.oc.commons.core.inject.HybridManifest;
@@ -11,6 +13,7 @@ import tc.oc.pgm.chat.MatchFlairRenderer;
 import tc.oc.pgm.chat.MatchNameInvalidator;
 import tc.oc.pgm.chat.MatchUsernameRenderer;
 import tc.oc.pgm.commands.AdminCommands;
+import tc.oc.pgm.commands.CommandUtils;
 import tc.oc.pgm.commands.MatchCommands;
 import tc.oc.pgm.commands.PollCommands;
 import tc.oc.pgm.debug.PGMLeakListener;
@@ -106,5 +109,11 @@ public final class PGMManifest extends HybridManifest {
         requestStaticInjection(State.class);
         requestStaticInjection(PollCommands.class);
         requestStaticInjection(MatchFooterTabEntry.class);
+        requestStaticInjection(CommandUtils.class);
+    }
+
+    @Provides
+    PGM pgm(Plugin plugin) {
+        return (PGM) plugin;
     }
 }

--- a/PGM/src/main/java/tc/oc/pgm/PGMManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/PGMManifest.java
@@ -6,15 +6,13 @@ import tc.oc.commons.bukkit.flairs.FlairRenderer;
 import tc.oc.commons.bukkit.nick.UsernameRenderer;
 import tc.oc.commons.core.inject.HybridManifest;
 import tc.oc.commons.core.plugin.PluginFacetBinder;
-import tc.oc.minecraft.api.event.ListenerBinder;
 import tc.oc.pgm.analytics.MatchAnalyticsManifest;
 import tc.oc.pgm.antigrief.DefuseListener;
 import tc.oc.pgm.chat.MatchFlairRenderer;
 import tc.oc.pgm.chat.MatchNameInvalidator;
 import tc.oc.pgm.chat.MatchUsernameRenderer;
-import tc.oc.pgm.commands.AdminCommands;
+import tc.oc.pgm.commands.CommandManifest;
 import tc.oc.pgm.commands.CommandUtils;
-import tc.oc.pgm.commands.MatchCommands;
 import tc.oc.pgm.commands.PollCommands;
 import tc.oc.pgm.debug.PGMLeakListener;
 import tc.oc.pgm.development.MapDevelopmentCommands;
@@ -39,7 +37,7 @@ import tc.oc.pgm.match.MatchPlayerEventRouter;
 import tc.oc.pgm.module.MatchModulesManifest;
 import tc.oc.pgm.mutation.command.MutationCommands;
 import tc.oc.pgm.restart.RestartListener;
-import tc.oc.pgm.rotation.DynamicRotationListener;
+import tc.oc.pgm.rotation.RotationManifest;
 import tc.oc.pgm.settings.Settings;
 import tc.oc.pgm.spawns.states.State;
 import tc.oc.pgm.tablist.MatchFooterTabEntry;
@@ -67,13 +65,16 @@ public final class PGMManifest extends HybridManifest {
 
         install(new ListingManifest());
 
+        install(new CommandManifest());
+
+        install(new RotationManifest());
+
         bind(MatchManager.class);
         bind(MatchLoader.class);
         bind(MatchFinder.class).to(MatchLoader.class);
 
         bind(MapLibrary.class).to(MapLibraryImpl.class);
         bind(MapLoader.class).to(MapLoaderImpl.class);
-        new ListenerBinder(binder()).bindListener().to(DynamicRotationListener.class);
 
         // Tourney needs this
         expose(MapLibrary.class);
@@ -84,13 +85,11 @@ public final class PGMManifest extends HybridManifest {
         bindAndExpose(FlairRenderer.class).to(MatchFlairRenderer.class);
 
         final PluginFacetBinder facets = new PluginFacetBinder(binder());
-        facets.register(AdminCommands.class);
         facets.register(PollCommands.class);
         facets.register(MatchNameInvalidator.class);
         facets.register(MapDevelopmentCommands.class);
         facets.register(MapErrorTracker.class);
         facets.register(MatchAnnouncer.class);
-        facets.register(MatchCommands.class);
         facets.register(MutationCommands.class);
         facets.register(MutationCommands.Parent.class);
         facets.register(PGMLeakListener.class);

--- a/PGM/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -193,16 +193,16 @@ public class AdminCommands {
 
             BaseComponent compound = n == 1 ? new Component("maps.singularCompund")
                                             : new TranslatableComponent("maps.pluralCompound", String.valueOf(n));
-            // TODO: rewrite MapInfo to return Components
-            BaseComponent nextMapDescription = new Component(rotation.getNext().getInfo().getShortDescription(sender));
-            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.successMultiple", compound, nextMapDescription));
+
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.successMultiple",
+                compound,
+                rotation.getNext().getInfo().getShortDescription()));
 
         } else {
             PGMMap skippedMap = rotation.getNext();
             rotation = rotation.skip(1);
-            // TODO: rewrite
-            BaseComponent skippedMapDescription = new Component(skippedMap.getInfo().getShortDescription(sender));
-            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.success", skippedMapDescription));
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.success",
+                                                                          skippedMap.getInfo().getShortDescription()));
         }
 
         manager.setRotation(rotation);
@@ -225,9 +225,8 @@ public class AdminCommands {
         if(RotationState.isNextIdValid(rotation.getMaps(), newNextId)) {
             rotation = rotation.skipTo(newNextId);
             manager.setRotation(rotation);
-            // TODO: rewrite
-            BaseComponent nextMapDescription = new Component(rotation.getNext().getInfo().getShortDescription(sender));
-            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skipto.success", nextMapDescription));
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skipto.success",
+                                                                          rotation.getNext().getInfo().getShortDescription()));
         } else {
             throw new TranslatableCommandException("command.admin.skipto.invalidPoint");
         }

--- a/PGM/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -14,10 +14,9 @@ import net.md_5.bungee.api.chat.TranslatableComponent;
 import org.bukkit.command.CommandSender;
 import java.time.Duration;
 import tc.oc.api.docs.virtual.ServerDoc;
+import tc.oc.commons.bukkit.chat.Audiences;
 import tc.oc.commons.core.chat.Audience;
-import tc.oc.commons.core.chat.Audiences;
 import tc.oc.commons.core.chat.Component;
-import tc.oc.commons.core.commands.Commands;
 import tc.oc.commons.core.commands.TranslatableCommandException;
 import tc.oc.commons.core.restart.RestartManager;
 import tc.oc.commons.core.util.TimeUtils;
@@ -36,7 +35,7 @@ import tc.oc.pgm.victory.VictoryMatchModule;
 import tc.oc.pgm.rotation.RotationManager;
 import tc.oc.pgm.rotation.RotationState;
 
-public class AdminCommands implements Commands {
+public class AdminCommands {
     
     private final RestartManager restartManager;
     private final RestartListener restartListener;
@@ -94,9 +93,9 @@ public class AdminCommands implements Commands {
             audience.sendMessage(new Component(ChatColor.RED).translate("command.admin.ppr.match-count-disabled"));
         } else if(matches > 0) {
             restartManager.cancelRestart();
-            audience.sendMessage(new Component(ChatColor.RED).translate("command.admin.ppr-restart-in-matches"));
+            audience.sendMessage(new Component(ChatColor.RED).translate("command.admin.ppr.restart-in-matches", matches));
         } else if(matches == 0) {
-            audience.sendMessage(new Component(ChatColor.RED).translate("command.admin.ppr-restart-after-match"));
+            audience.sendMessage(new Component(ChatColor.RED).translate("command.admin.ppr.restart-after-match"));
         }
     }
 
@@ -169,8 +168,10 @@ public class AdminCommands implements Commands {
     )
     @CommandPermissions("pgm.cancel")
     public void cancel(CommandContext args, CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
+
         CommandUtils.getMatch(sender).countdowns().cancelAll(true);
-        sender.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.cancel.success"));
+        audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.cancel.success"));
     }
 
     @Command(
@@ -182,26 +183,26 @@ public class AdminCommands implements Commands {
     )
     @CommandPermissions("pgm.skip")
     public void skip(CommandContext args, CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
         RotationManager manager = matchManager.getRotationManager();
         RotationState rotation = manager.getRotation();
 
         if(args.argsLength() > 0) {
             int n = args.getInteger(0, 1);
             rotation = rotation.skip(n);
-            // ChatColor.GREEN + PGMTranslations.get().t("command.admin.skip.successMultiple", sender, PGMTranslations.get().t(n == 1 ? "maps.singularCompound" : "maps.pluralCompound", sender, n),
-            // rotation.getNext().getInfo().getShortDescription(sender) + ChatColor.GREEN
+
             BaseComponent compound = n == 1 ? new Component("maps.singularCompund")
                                             : new TranslatableComponent("maps.pluralCompound", String.valueOf(n));
             // TODO: rewrite MapInfo to return Components
             BaseComponent nextMapDescription = new Component(rotation.getNext().getInfo().getShortDescription(sender));
-            sender.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.successMultiple", compound, nextMapDescription));
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.successMultiple", compound, nextMapDescription));
 
         } else {
             PGMMap skippedMap = rotation.getNext();
             rotation = rotation.skip(1);
             // TODO: rewrite
             BaseComponent skippedMapDescription = new Component(skippedMap.getInfo().getShortDescription(sender));
-            sender.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.success", skippedMapDescription));
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skip.success", skippedMapDescription));
         }
 
         manager.setRotation(rotation);
@@ -216,6 +217,7 @@ public class AdminCommands implements Commands {
     )
     @CommandPermissions("pgm.skip")
     public void skipto(CommandContext args, CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
         RotationManager manager = matchManager.getRotationManager();
         RotationState rotation = manager.getRotation();
 
@@ -225,7 +227,7 @@ public class AdminCommands implements Commands {
             manager.setRotation(rotation);
             // TODO: rewrite
             BaseComponent nextMapDescription = new Component(rotation.getNext().getInfo().getShortDescription(sender));
-            sender.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skipto.success", nextMapDescription));
+            audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.skipto.success", nextMapDescription));
         } else {
             throw new TranslatableCommandException("command.admin.skipto.invalidPoint");
         }
@@ -240,9 +242,10 @@ public class AdminCommands implements Commands {
     )
     @CommandPermissions("pgm.reload")
     public void pgm(CommandContext args, CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
         pgm.reloadConfig();
 
-        sender.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.pgm"));
+        audience.sendMessage(new Component(ChatColor.GREEN).translate("command.admin.pgm"));
     }
 
     @Command(

--- a/PGM/src/main/java/tc/oc/pgm/commands/CommandManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/CommandManifest.java
@@ -6,8 +6,9 @@ import tc.oc.commons.core.inject.HybridManifest;
 public class CommandManifest extends HybridManifest {
     @Override
     protected void configure() {
-        new CommandBinder(binder()).register(AdminCommands.class);
-        new CommandBinder(binder()).register(MapCommands.class);
-        new CommandBinder(binder()).register(MatchCommands.class);
+        CommandBinder binder = new CommandBinder(binder());
+        binder.register(AdminCommands.class);
+        binder.register(MapCommands.class);
+        binder.register(MatchCommands.class);
     }
 }

--- a/PGM/src/main/java/tc/oc/pgm/commands/CommandManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/CommandManifest.java
@@ -1,0 +1,13 @@
+package tc.oc.pgm.commands;
+
+import tc.oc.commons.core.commands.CommandBinder;
+import tc.oc.commons.core.inject.HybridManifest;
+
+public class CommandManifest extends HybridManifest {
+    @Override
+    protected void configure() {
+        new CommandBinder(binder()).register(AdminCommands.class);
+        new CommandBinder(binder()).register(MapCommands.class);
+        new CommandBinder(binder()).register(MatchCommands.class);
+    }
+}

--- a/PGM/src/main/java/tc/oc/pgm/commands/CommandUtils.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/CommandUtils.java
@@ -4,24 +4,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.inject.Inject;
 
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
 import org.bukkit.command.CommandSender;
+import tc.oc.commons.core.commands.TranslatableCommandException;
 import tc.oc.commons.core.formatting.StringUtils;
 import tc.oc.pgm.PGM;
-import tc.oc.pgm.PGMTranslations;
 import tc.oc.pgm.features.FeatureDefinition;
 import tc.oc.pgm.map.MapLibrary;
 import tc.oc.pgm.map.PGMMap;
 import tc.oc.pgm.match.Competitor;
 import tc.oc.pgm.match.Match;
+import tc.oc.pgm.match.MatchManager;
 import tc.oc.pgm.match.MatchModule;
 import tc.oc.pgm.match.MatchPlayer;
 import tc.oc.pgm.rotation.RotationManager;
 import tc.oc.pgm.rotation.RotationState;
 
 public class CommandUtils {
+    @Inject private static MatchManager matchManager;
 
     public static List<String> completeMapName(String prefix) {
         return StringUtils.complete(prefix, PGM.get().getMapLibrary().getMapNames());
@@ -40,15 +43,15 @@ public class CommandUtils {
     public static PGMMap getMap(String search, CommandSender sender) throws CommandException {
         PGMMap map;
         if((map = getMap(search)) == null) {
-            throw new CommandException(PGMTranslations.get().t("command.mapNotFound", sender));
+            throw new TranslatableCommandException("command.mapNotFound");
         }
         return map;
     }
 
     public static Match getMatch(CommandSender sender) throws CommandException {
-        Match match = PGM.getMatchManager().getCurrentMatch(sender);
+        Match match = matchManager.getCurrentMatch(sender);
         if(match == null) {
-            throw new CommandException("Command must be used in the context of a match");
+            throw new TranslatableCommandException("command.context");
         }
         return match;
     }
@@ -56,7 +59,7 @@ public class CommandUtils {
     public static <T extends MatchModule> T getMatchModule(Class<T> klass, CommandSender sender) throws CommandException {
         T mm = getMatch(sender).getMatchModule(klass);
         if(mm == null) {
-            throw new CommandException(PGMTranslations.get().t("command.moduleNotFound", sender, klass.getSimpleName()));
+            throw new TranslatableCommandException("command.moduleNotFound", klass.getSimpleName());
         }
         return mm;
     }
@@ -71,18 +74,18 @@ public class CommandUtils {
 
         Competitor competitor = StringUtils.bestFuzzyMatch(search, byName, 0.9);
         if(competitor == null) {
-            throw new CommandException(PGMTranslations.get().t("command.competitorNotFound", sender));
+            throw new TranslatableCommandException("command.competitorNotFound");
         }
 
         return competitor;
     }
 
     public static @Nonnull RotationState getRotation(String search, CommandSender sender) throws CommandException {
-        RotationManager manager = PGM.getMatchManager().getRotationManager();
+        RotationManager manager = matchManager.getRotationManager();
 
         RotationState rotation = search != null ? manager.getRotation(search) : manager.getRotation();
         if(rotation == null) {
-            throw new CommandException(PGMTranslations.get().t("command.rotationNotFound", sender));
+            throw new TranslatableCommandException("command.rotationNotFound");
         }
 
         return rotation;
@@ -92,7 +95,7 @@ public class CommandUtils {
         Match match = getMatch(sender);
         T feature = match.getModuleContext().features().get(id, type);
         if(feature == null) {
-            throw new CommandException("No " + type.getSimpleName() + " with ID " + id);
+            throw new TranslatableCommandException("command.noFeature", type.getSimpleName(), id);
         }
         return feature;
     }

--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.commands;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
@@ -17,7 +16,6 @@ import com.sk89q.minecraft.util.commands.CommandPermissions;
 import java.util.stream.Collectors;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 import org.bukkit.command.CommandSender;
 import tc.oc.api.docs.User;
@@ -39,7 +37,8 @@ import tc.oc.commons.core.chat.Component;
 import tc.oc.commons.core.chat.Components;
 import tc.oc.commons.core.commands.CommandFutureCallback;
 import tc.oc.commons.core.commands.Commands;
-import tc.oc.minecraft.scheduler.SyncExecutor;
+import tc.oc.commons.core.concurrent.Flexecutor;
+import tc.oc.minecraft.scheduler.Sync;
 import tc.oc.pgm.PGM;
 import tc.oc.pgm.PGMTranslations;
 import tc.oc.pgm.ffa.FreeForAllModule;
@@ -54,14 +53,14 @@ import tc.oc.pgm.teams.TeamFactory;
 
 public class MapCommands implements Commands {
     private final UserFinder userFinder;
-    private final SyncExecutor syncExecutor;
+    private final Flexecutor executor;
     private final IdentityProvider identityProvider;
     private final ComponentRenderContext renderer;
 
-    @Inject MapCommands(UserFinder userFinder, IdentityProvider identityProvider, SyncExecutor syncExecutor, ComponentRenderContext renderer) {
+    @Inject MapCommands(UserFinder userFinder, IdentityProvider identityProvider, @Sync Flexecutor executor, ComponentRenderContext renderer) {
         this.userFinder = userFinder;
         this.identityProvider = identityProvider;
-        this.syncExecutor = syncExecutor;
+        this.executor = executor;
         this.renderer = renderer;
     }
 
@@ -80,7 +79,7 @@ public class MapCommands implements Commands {
         final MapDoc.Gamemode gamemode = parseGamemode(args.getFlag('g'));
         final String author = args.getFlag('a');
         if(args.getFlag('a') != null) {
-            syncExecutor.callback(
+            executor.callback(
                 userFinder.findUser(sender, author, UserFinder.Scope.ALL, UserFinder.Default.NULL),
                 CommandFutureCallback.onSuccess(sender, result -> {
                     BaseComponent displayMsg = gamemode != null ?
@@ -266,6 +265,7 @@ public class MapCommands implements Commands {
             audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.source"), new Component(map.getSource().getPath().toString(), ChatColor.GOLD)));
         }
 
+        /*
         URL xmlLink = map.getFolder().getDescriptionFileUrl();
         if(xmlLink != null) {
             audience.sendMessage(new Component(
@@ -280,6 +280,7 @@ public class MapCommands implements Commands {
 
             ));
         }
+        */
 
         return null;
     }

--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -147,7 +147,7 @@ public class MapCommands {
         new PrettyPaginatedResult<PGMMap>(renderer.renderLegacy(title, sender)) {
             @Override
             public String format(PGMMap pgmMap, int i) {
-                return (i + 1) + ". " + pgmMap.getInfo().getShortDescription(sender);
+                return (i + 1) + ". " + pgmMap.getInfo().getShortDescription().toLegacyText();
             }
         }.display(new BukkitWrappedCommandSender(sender), maps, args.getInteger(0, 1) /*page*/);
     }
@@ -180,8 +180,7 @@ public class MapCommands {
         final InfoModule infoModule = map.getContext().needModule(InfoModule.class);
         final MapInfo mapInfo = infoModule.getMapInfo();
 
-        // TODO: refactor the method in MapInfo to return components instead
-        audience.sendMessage(new Component(mapInfo.getFormattedMapTitle()));
+        audience.sendMessage(mapInfo.getFormattedMapTitle());
 
         Set<MapDoc.Gamemode> gamemodes = infoModule.getGamemodes();
         if(gamemodes.size() == 1) {
@@ -312,7 +311,7 @@ public class MapCommands {
         new PrettyPaginatedResult<PGMMap>(header) {
             @Override public String format(PGMMap map, int index) {
                 ChatColor color = index == rotation.getNextId() ? ChatColor.DARK_AQUA : ChatColor.WHITE;
-                return color.toString() + (index + 1) + ". " + map.getInfo().getShortDescription(sender);
+                return color.toString() + (index + 1) + ". " + map.getInfo().getShortDescription().toLegacyText();
             }
         }.display(new BukkitWrappedCommandSender(sender), rotation.getMaps(), page);
     }
@@ -352,9 +351,10 @@ public class MapCommands {
     )
     @CommandPermissions("pgm.mapnext")
     public void mapnext(CommandContext args, CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
         PGMMap next = matchManager.getNextMap();
-        // TODO: Make this a component
-        sender.sendMessage(ChatColor.DARK_PURPLE + PGMTranslations.get().t("command.map.next.success", sender, next.getInfo().getShortDescription(sender) + ChatColor.DARK_PURPLE));
+        audience.sendMessage(new Component(ChatColor.DARK_PURPLE).translate("command.map.next.success",
+                                                                            next.getInfo().getShortDescription()));
     }
 
     private static @Nullable BaseComponent formatContribution(Contributor contributor) {

--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -36,7 +36,6 @@ import tc.oc.commons.core.chat.Audience;
 import tc.oc.commons.core.chat.Component;
 import tc.oc.commons.core.chat.Components;
 import tc.oc.commons.core.commands.CommandFutureCallback;
-import tc.oc.commons.core.commands.Commands;
 import tc.oc.commons.core.concurrent.Flexecutor;
 import tc.oc.minecraft.scheduler.Sync;
 import tc.oc.pgm.PGM;
@@ -52,7 +51,7 @@ import tc.oc.pgm.rotation.RotationProviderInfo;
 import tc.oc.pgm.rotation.RotationState;
 import tc.oc.pgm.teams.TeamFactory;
 
-public class MapCommands implements Commands {
+public class MapCommands {
     private final UserFinder userFinder;
     private final Flexecutor executor;
     private final IdentityProvider identityProvider;
@@ -300,12 +299,12 @@ public class MapCommands implements Commands {
         max = 1
     )
     @CommandPermissions("pgm.rotation.view")
-    public static void rotation(CommandContext args, final CommandSender sender) throws CommandException {
+    public void rotation(CommandContext args, final CommandSender sender) throws CommandException {
         final RotationState rotation = CommandUtils.getRotation(args.getFlag('n'), sender);
         int page = args.getInteger(0, 1);
 
         String header = PGMTranslations.get().t("command.map.currentRotation.title", sender);
-        String name = PGM.getMatchManager().getRotationManager().getCurrentRotationName();
+        String name = matchManager.getRotationManager().getCurrentRotationName();
         if(!name.equalsIgnoreCase("default")) {
             header += " (" + ChatColor.DARK_AQUA + name + ChatColor.RESET + ")";
         }
@@ -327,8 +326,8 @@ public class MapCommands implements Commands {
         max = 0
     )
     @CommandPermissions("pgm.rotation.list")
-    public static void rotations(final CommandContext args, final CommandSender sender) throws CommandException {
-        RotationManager manager = PGM.getMatchManager().getRotationManager();
+    public void rotations(final CommandContext args, final CommandSender sender) throws CommandException {
+        RotationManager manager = matchManager.getRotationManager();
         List<RotationProviderInfo> rotations = manager.getProviders();
         int page = args.getFlagInteger('p', 1);
 

--- a/PGM/src/main/java/tc/oc/pgm/commands/MatchCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MatchCommands.java
@@ -7,10 +7,9 @@ import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import org.bukkit.command.CommandSender;
-import tc.oc.commons.core.commands.Commands;
 import tc.oc.pgm.match.MatchFormatter;
 
-public class MatchCommands implements Commands {
+public class MatchCommands {
 
     private final MatchFormatter formatter;
 

--- a/PGM/src/main/java/tc/oc/pgm/commands/RotationControlCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/RotationControlCommands.java
@@ -1,15 +1,25 @@
 package tc.oc.pgm.commands;
 
-import org.bukkit.ChatColor;
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+import com.sk89q.minecraft.util.commands.NestedCommand;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 
-import tc.oc.pgm.PGM;
+import tc.oc.commons.core.chat.Component;
+import tc.oc.commons.core.commands.Commands;
+import tc.oc.commons.core.commands.NestedCommands;
+import tc.oc.pgm.match.MatchManager;
 import tc.oc.pgm.rotation.RotationManager;
 
-import com.sk89q.minecraft.util.commands.*;
 
-public class RotationControlCommands {
-    public static class RotationControlParent {
+import javax.inject.Inject;
+
+// TODO: properly bind commands
+public class RotationControlCommands implements NestedCommands {
+    public static class RotationControlParent implements Commands {
         @Command(
             aliases = {"rotationcontrol", "rotcontrol", "rotcon", "controlrotation", "controlrot", "crot"},
             desc = "Commands for controlling the rotation",
@@ -21,6 +31,12 @@ public class RotationControlCommands {
         }
     }
 
+    private final MatchManager matchManager;
+
+    @Inject RotationControlCommands(MatchManager matchManager) {
+        this.matchManager = matchManager;
+    }
+
     @Command(
         aliases = {"set", "s"},
         desc = "Sets the current rotation",
@@ -28,13 +44,13 @@ public class RotationControlCommands {
         max = -1
     )
     @CommandPermissions("pgm.rotation.set")
-    public static void info(final CommandContext args, final CommandSender sender) throws CommandException {
-        RotationManager manager = PGM.getMatchManager().getRotationManager();
+    public void info(final CommandContext args, final CommandSender sender) throws CommandException {
+        RotationManager manager = matchManager.getRotationManager();
 
         String name = args.getJoinedStrings(0);
         CommandUtils.getRotation(name, sender);
 
         manager.setCurrentRotationName(name);
-        sender.sendMessage(ChatColor.GRAY + "Current rotation set to " + ChatColor.AQUA + name);
+        sender.sendMessage(new Component(ChatColor.GRAY).translate("command.rotation.set.success", new Component(name).color(ChatColor.AQUA)));
     }
 }

--- a/PGM/src/main/java/tc/oc/pgm/map/MapInfo.java
+++ b/PGM/src/main/java/tc/oc/pgm/map/MapInfo.java
@@ -1,21 +1,21 @@
 package tc.oc.pgm.map;
 
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Iterables;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 import org.bukkit.Difficulty;
 import org.bukkit.World.Environment;
-import org.bukkit.command.CommandSender;
 import tc.oc.api.docs.PlayerId;
 import tc.oc.api.docs.SemanticVersion;
 import tc.oc.api.docs.virtual.MapDoc;
-import tc.oc.commons.bukkit.localization.Translations;
+import tc.oc.commons.bukkit.chat.ListComponent;
+import tc.oc.commons.bukkit.chat.NameStyle;
 import tc.oc.commons.core.chat.Component;
 import tc.oc.commons.core.chat.Components;
 import tc.oc.commons.core.formatting.StringUtils;
@@ -102,37 +102,30 @@ public class MapInfo implements Comparable<MapInfo> {
     public MapDoc.Edition edition() { return id.edition(); }
     public MapDoc.Phase phase() { return id.phase(); }
 
-    public String getFormattedMapTitle() {
-        return StringUtils.dashedChatMessage(DARK_AQUA + " " + this.name + GRAY + " " + version, "-", RED + "" + STRIKETHROUGH);
+    public BaseComponent getFormattedMapTitle() {
+        return new Component(StringUtils.dashedChatMessage(DARK_AQUA + " " + this.name + GRAY + " " + version, "-", RED + "" + STRIKETHROUGH));
     }
 
-    public String getShortDescription(CommandSender sender) {
-        String text = GOLD + this.name;
+    public BaseComponent getShortDescription() {
+        BaseComponent componentedName = new Component(name).color(GOLD);
 
         List<Contributor> authors = getNamedAuthors();
         if(!authors.isEmpty()) {
-            text = Translations.get().t(
-                DARK_PURPLE.toString(),
-                "misc.authorship",
-                sender,
-                text,
-                Translations.get().legacyList(
-                    sender,
-                    DARK_PURPLE.toString(),
-                    RED.toString(),
-                    authors
-                )
-            );
+            componentedName = new Component(DARK_PURPLE).translate("misc.authorship",
+                                                                    componentedName,
+                                                                    new ListComponent(Lists.transform(authors,
+                                                                        contributors -> contributors.getStyledName(NameStyle.MAPMAKER)
+                                                                    )));
         }
 
-        return text;
+        return componentedName;
     }
 
     /**
      * Apply standard formatting (aqua + bold) to the map name
      */
-    public String getColoredName() {
-        return AQUA.toString() + BOLD + this.name;
+    public BaseComponent getColoredName() {
+        return new Component(name).color(AQUA).bold(true);
     }
 
     public BaseComponent getComponentName() {
@@ -142,8 +135,8 @@ public class MapInfo implements Comparable<MapInfo> {
     /**
      * Apply standard formatting (aqua + bold) to the map version
      */
-    public String getColoredVersion() {
-        return DARK_AQUA.toString() + BOLD + version;
+    public BaseComponent getColoredVersion() {
+        return new Component(version.toString()).color(AQUA).bold(true);
     }
 
     public List<Contributor> getNamedAuthors() {

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationControlCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationControlCommands.java
@@ -17,7 +17,6 @@ import tc.oc.pgm.match.MatchManager;
 
 import javax.inject.Inject;
 
-// TODO: properly bind commands
 public class RotationControlCommands {
     public static class RotationControlParent {
         @Command(
@@ -51,9 +50,9 @@ public class RotationControlCommands {
         RotationManager manager = matchManager.getRotationManager();
 
         String name = args.getJoinedStrings(0);
-        CommandUtils.getRotation(name, sender);
+        RotationState state = CommandUtils.getRotation(name, sender);
 
-        manager.setCurrentRotationName(name);
+        manager.setRotation(state);
         audience.sendMessage(new Component(ChatColor.GRAY).translate("command.rotation.set.success", new Component(name).color(ChatColor.AQUA)));
     }
 }

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationControlCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationControlCommands.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.commands;
+package tc.oc.pgm.rotation;
 
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
@@ -8,18 +8,18 @@ import com.sk89q.minecraft.util.commands.NestedCommand;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 
+import tc.oc.commons.core.chat.Audience;
+import tc.oc.commons.bukkit.chat.Audiences;
 import tc.oc.commons.core.chat.Component;
-import tc.oc.commons.core.commands.Commands;
-import tc.oc.commons.core.commands.NestedCommands;
+import tc.oc.pgm.commands.CommandUtils;
 import tc.oc.pgm.match.MatchManager;
-import tc.oc.pgm.rotation.RotationManager;
 
 
 import javax.inject.Inject;
 
 // TODO: properly bind commands
-public class RotationControlCommands implements NestedCommands {
-    public static class RotationControlParent implements Commands {
+public class RotationControlCommands {
+    public static class RotationControlParent {
         @Command(
             aliases = {"rotationcontrol", "rotcontrol", "rotcon", "controlrotation", "controlrot", "crot"},
             desc = "Commands for controlling the rotation",
@@ -32,9 +32,11 @@ public class RotationControlCommands implements NestedCommands {
     }
 
     private final MatchManager matchManager;
+    private final Audiences audiences;
 
-    @Inject RotationControlCommands(MatchManager matchManager) {
+    @Inject RotationControlCommands(MatchManager matchManager, Audiences audiences) {
         this.matchManager = matchManager;
+        this.audiences = audiences;
     }
 
     @Command(
@@ -45,12 +47,13 @@ public class RotationControlCommands implements NestedCommands {
     )
     @CommandPermissions("pgm.rotation.set")
     public void info(final CommandContext args, final CommandSender sender) throws CommandException {
+        final Audience audience = audiences.get(sender);
         RotationManager manager = matchManager.getRotationManager();
 
         String name = args.getJoinedStrings(0);
         CommandUtils.getRotation(name, sender);
 
         manager.setCurrentRotationName(name);
-        sender.sendMessage(new Component(ChatColor.GRAY).translate("command.rotation.set.success", new Component(name).color(ChatColor.AQUA)));
+        audience.sendMessage(new Component(ChatColor.GRAY).translate("command.rotation.set.success", new Component(name).color(ChatColor.AQUA)));
     }
 }

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationEditCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationEditCommands.java
@@ -11,7 +11,6 @@ import org.bukkit.command.CommandSender;
 import tc.oc.commons.bukkit.chat.Audiences;
 import tc.oc.commons.core.chat.Audience;
 import tc.oc.commons.core.chat.Component;
-import tc.oc.commons.core.commands.NestedCommands;
 import tc.oc.commons.core.commands.TranslatableCommandException;
 import tc.oc.pgm.commands.CommandUtils;
 import tc.oc.pgm.map.PGMMap;
@@ -19,7 +18,7 @@ import tc.oc.pgm.match.MatchManager;
 
 import javax.inject.Inject;
 
-public class RotationEditCommands implements NestedCommands {
+public class RotationEditCommands {
     public static class RotationEditParent {
         @Command(
             aliases = {"rotationedit", "rotedit", "roted", "editrotation", "editrot", "erot"},
@@ -70,7 +69,6 @@ public class RotationEditCommands implements NestedCommands {
         PGMMap map = CommandUtils.getMap(args.getJoinedStrings(0), sender);
 
         apply(new AppendTransformation(map));
-        // TODO: rewrite
         audience.sendMessage(new Component(ChatColor.DARK_PURPLE).translate("command.rotation.append.success", new Component(map.getInfo().name).color(ChatColor.GOLD)));
     }
 
@@ -88,7 +86,6 @@ public class RotationEditCommands implements NestedCommands {
         PGMMap map = CommandUtils.getMap(args.getJoinedStrings(1), sender);
 
         apply(new InsertTransformation(map, index - 1));
-        // ChatColor.GOLD + map.getInfo().name + ChatColor.DARK_PURPLE + " inserted at index " + index
         audience.sendMessage(new Component(ChatColor.DARK_PURPLE)
             .translate("command.rotation.insert.success",
                 new Component(map.getInfo().name).color(ChatColor.GOLD),
@@ -108,7 +105,6 @@ public class RotationEditCommands implements NestedCommands {
         PGMMap map = CommandUtils.getMap(args.getJoinedStrings(0), sender);
 
         apply(new RemoveAllTransformation(map));
-        // TODO: rewrite
         audience.sendMessage(new Component(ChatColor.DARK_PURPLE).translate("command.rotation.remove.success", new Component(map.getInfo().name).color(ChatColor.GOLD)));
     }
 
@@ -125,7 +121,6 @@ public class RotationEditCommands implements NestedCommands {
         int index = args.getInteger(0);
 
         apply(new RemoveIndexTransformation(index - 1));
-        // TODO: rewrite
         audience.sendMessage(new Component(ChatColor.DARK_PURPLE).translate("command.rotation.removeat.success", String.valueOf(index)));
     }
 

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationManifest.java
@@ -1,0 +1,15 @@
+package tc.oc.pgm.rotation;
+
+import tc.oc.commons.core.commands.CommandBinder;
+import tc.oc.commons.core.inject.HybridManifest;
+import tc.oc.minecraft.api.event.ListenerBinder;
+
+public class RotationManifest extends HybridManifest {
+    @Override
+    protected void configure() {
+        bind(DynamicRotationListener.class);
+        new ListenerBinder(binder()).bindListener().to(DynamicRotationListener.class);
+        new CommandBinder(binder()).register(RotationControlCommands.RotationControlParent.class);
+        new CommandBinder(binder()).register(RotationEditCommands.RotationEditParent.class);
+    }
+}

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationManifest.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationManifest.java
@@ -9,7 +9,8 @@ public class RotationManifest extends HybridManifest {
     protected void configure() {
         bind(DynamicRotationListener.class);
         new ListenerBinder(binder()).bindListener().to(DynamicRotationListener.class);
-        new CommandBinder(binder()).register(RotationControlCommands.RotationControlParent.class);
-        new CommandBinder(binder()).register(RotationEditCommands.RotationEditParent.class);
+        CommandBinder binder = new CommandBinder(binder());
+        binder.register(RotationControlCommands.RotationControlParent.class);
+        binder.register(RotationEditCommands.RotationEditParent.class);
     }
 }


### PR DESCRIPTION
XML links now point to some stratus.nyc3.digitaloceanspaces URL, which is inaccessible. This commit temporarily removes the link displayed in /map until the URL is fixed. This commit also starts the cleanup of the various commands classes in the PGM submodule.