### PR TITLE
Make map context a soft reference, and keep a persistent context

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -174,7 +174,7 @@ public class MapCommands implements Commands {
             map = CommandUtils.getMatch(sender).getMap();
         }
 
-        final InfoModule infoModule = map.getContext().needModule(InfoModule.class);
+        final InfoModule infoModule = map.getPersistentContext().getInfoModule();
         final MapInfo mapInfo = infoModule.getMapInfo();
 
         audience.sendMessage(mapInfo.getFormattedMapTitle());
@@ -243,16 +243,7 @@ public class MapCommands implements Commands {
             }
         }
 
-        int maxPlayers = map.getContext()
-                            .features()
-                            .all(TeamFactory.class)
-                            .mapToInt(TeamFactory::getMaxPlayers)
-                            .sum();
-
-        FreeForAllModule ffam = map.getContext().getModule(FreeForAllModule.class);
-        if(ffam != null) {
-            maxPlayers += ffam.getOptions().maxPlayers;
-        }
+        int maxPlayers = map.getPersistentContext().playerLimits().upperEndpoint();
 
         audience.sendMessage(new Component(
             mapInfoLabel("command.map.mapInfo.playerLimit"),
@@ -261,7 +252,7 @@ public class MapCommands implements Commands {
 
         if(sender.hasPermission(Permissions.MAPDEV)) {
             audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.genre"), new Component(mapInfo.getLocalizedGenre(), ChatColor.GOLD)));
-            audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.proto"), new Component(map.getContext().getProto().toString(), ChatColor.GOLD)));
+            audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.proto"), new Component(map.getPersistentContext().getProto().toString(), ChatColor.GOLD)));
             audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.folder"), new Component(map.getFolder().getRelativePath().toString(), ChatColor.GOLD)));
             audience.sendMessage(new Component(mapInfoLabel("command.map.mapInfo.source"), new Component(map.getSource().getPath().toString(), ChatColor.GOLD)));
         }

--- a/PGM/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/PGM/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -120,11 +120,11 @@ public class CycleMatchModule extends MatchModule implements Listener {
                         }
 
                         @Override public int min_players() {
-                            return nextMap.getContext().playerLimits().lowerEndpoint();
+                            return nextMap.getPersistentContext().playerLimits().lowerEndpoint();
                         }
 
                         @Override public int max_players() {
-                            return nextMap.getContext().playerLimits().upperEndpoint();
+                            return nextMap.getPersistentContext().playerLimits().upperEndpoint();
                         }
                     }
                 ),

--- a/PGM/src/main/java/tc/oc/pgm/development/MapDevelopmentCommands.java
+++ b/PGM/src/main/java/tc/oc/pgm/development/MapDevelopmentCommands.java
@@ -59,6 +59,7 @@ import tc.oc.pgm.map.MapConfiguration;
 import tc.oc.pgm.map.MapDefinition;
 import tc.oc.pgm.map.MapLibrary;
 import tc.oc.pgm.map.MapLogRecord;
+import tc.oc.pgm.map.MapModuleContext;
 import tc.oc.pgm.map.MapNotFoundException;
 import tc.oc.pgm.map.PGMMap;
 import tc.oc.pgm.match.Match;
@@ -205,7 +206,10 @@ public class MapDevelopmentCommands implements Commands {
         final Optional<String> typeFilter = CommandUtils.flag(args, 't').map(String::toLowerCase);
         final Optional<String> idFilter = CommandUtils.flag(args, 'i').map(String::toLowerCase);
 
-        Stream<? extends FeatureDefinition> features = map.getContext().features().all();
+        MapModuleContext context = map.getContext().orElseThrow(() ->
+                new IllegalStateException("The map modules are currently unloaded."));
+
+        Stream<? extends FeatureDefinition> features = context.features().all();
         if(typeFilter.isPresent()) {
             features = features.filter(f -> f.inspectType().toLowerCase().contains(typeFilter.get()));
         }
@@ -222,7 +226,7 @@ public class MapDevelopmentCommands implements Commands {
             feature.inspectIdentity().ifPresent(id -> c.extra(" ").extra(new Component(id, ChatColor.YELLOW)));
 
             if(locate) {
-                final Element element = map.getContext().features().definitionNode(feature);
+                final Element element = context.features().definitionNode(feature);
                 if(element != null) {
                     c.extra(" ").extra(new Component(new Node(element).describeWithLocation(), ChatColor.DARK_AQUA));
                 }

--- a/PGM/src/main/java/tc/oc/pgm/map/MapPersistentContext.java
+++ b/PGM/src/main/java/tc/oc/pgm/map/MapPersistentContext.java
@@ -1,0 +1,49 @@
+package tc.oc.pgm.map;
+
+import com.google.common.collect.Range;
+import tc.oc.api.docs.SemanticVersion;
+import tc.oc.pgm.map.inject.MapScoped;
+import tc.oc.pgm.modules.InfoModule;
+
+import javax.inject.Inject;
+
+/**
+ * This is a replacement for classes that need information from MapModuleContext to use. MapModuleContext will not be
+ * guaranteed to be available if a match isn't being played for the map, but MapPersistentContext will always contain
+ * basic information required to reference the map (like map name, authors, or player amount).
+ */
+@MapScoped
+public class MapPersistentContext {
+
+    @Inject private @MapProto SemanticVersion proto;
+    @Inject private InfoModule infoModule;
+    private Range<Integer> playerLimits;
+    private MapDocument apiDocument;
+
+    @Inject public MapPersistentContext(MapModuleContext context) {
+        this.playerLimits = context.playerLimits();
+        this.apiDocument = context.apiDocument();
+    }
+
+    public MapDocument apiDocument() {
+        return apiDocument;
+    }
+
+    public SemanticVersion getProto() {
+        return proto;
+    }
+
+    public Range<Integer> playerLimits() {
+        return this.playerLimits;
+    }
+
+    public Integer playerLimitAverage() {
+        Range<Integer> lims = playerLimits();
+        return (lims.lowerEndpoint() + lims.upperEndpoint()) / 2;
+    }
+
+    public InfoModule getInfoModule() {
+        return infoModule;
+    }
+
+}

--- a/PGM/src/main/java/tc/oc/pgm/map/PGMMap.java
+++ b/PGM/src/main/java/tc/oc/pgm/map/PGMMap.java
@@ -48,7 +48,7 @@ public class PGMMap extends MapDefinition {
     }
 
     public MapInfo getInfo() {
-        return getContext().needModule(InfoModule.class).getMapInfo();
+        return getPersistentContext().getInfoModule().getMapInfo();
     }
 
     public MapId getId() {
@@ -56,7 +56,7 @@ public class PGMMap extends MapDefinition {
     }
 
     public MapDoc getDocument() {
-        return getContext().apiDocument();
+        return getPersistentContext().apiDocument();
     }
 
     @Override

--- a/PGM/src/main/java/tc/oc/pgm/match/MatchLoader.java
+++ b/PGM/src/main/java/tc/oc/pgm/match/MatchLoader.java
@@ -165,7 +165,7 @@ public class MatchLoader implements MatchFinder {
      * @param map Map to load.
      */
     private Match loadMatch(PGMMap map) throws Throwable {
-        return map.getContext().asCurrentScope(() -> {
+        return map.getContext().orElseThrow(MapNotFoundException::new).asCurrentScope(() -> {
             final WorldManager worldManager = this.worldManager.get();
             final String worldName = Match.createSlug(matchCounter.get());
             final World world = worldManager.createWorld(worldName);

--- a/PGM/src/main/java/tc/oc/pgm/rotation/RotationState.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/RotationState.java
@@ -43,7 +43,7 @@ public final class RotationState {
 
     
     private Lazy<Integer> averageNeededPlayers = Lazy.from(() ->
-            (int) getMaps().stream().mapToInt(map -> map.getContext().playerLimitAverage()).average().orElse(0));
+            (int) getMaps().stream().mapToInt(map -> map.getPersistentContext().playerLimitAverage()).average().orElse(0));
     
     /**
      * Gets the approximate number of players supposed to be playing the rotation maps.


### PR DESCRIPTION
With this change the maps will unload their modules when java is about to run out of memory. The JVM doesn't perform well when lacking memory, as it needs to constantly GC and that consumes a decent amount of CPU time, but this is able to make PGM load the whole OCN map repo (+1100 maps) with just 600MB of total heap space, without this change the server will crash and run out of memory unless you give it at least 900MB of heap space.

This has been tested just enough to make sure it runs and works as expected (when cycling to a map who's modules have been unloaded it reloads), but edge cases or some of the fixes or workarrounds implemented haven't been fully tested. 
Changes arround PGM were needed as it used to requiere a MapModuleContext to be always be loaded, while now the context may or may not be present. 
A MapPersistentContext with some basic info extracted from MapModuleContext has been added, and some operations that used to be async (like counting the amount of players a map allows, or generating a MapDocument) now have to be done sync on map load, as the modules may no longer be available later.