### PR TITLE
Prevent flags from dropping as items.

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/PGM/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -33,6 +33,7 @@ import org.bukkit.util.BlockVector;
 import tc.oc.commons.bukkit.chat.BukkitSound;
 import tc.oc.commons.bukkit.chat.NameStyle;
 import tc.oc.commons.bukkit.event.CoarsePlayerMoveEvent;
+import tc.oc.commons.bukkit.item.BooleanItemTag;
 import tc.oc.commons.bukkit.util.BukkitUtils;
 import tc.oc.commons.bukkit.util.Materials;
 import tc.oc.commons.bukkit.util.NMSHacks;
@@ -90,6 +91,8 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     public static final BukkitSound DROP_SOUND = new BukkitSound(Sound.ENTITY_FIREWORK_TWINKLE_FAR, 1f, 1f);
     public static final BukkitSound RETURN_SOUND = new BukkitSound(Sound.ENTITY_FIREWORK_TWINKLE_FAR, 1f, 1f);
 
+    private static final BooleanItemTag FLAG_ITEM = new BooleanItemTag("flag", false);
+
     private final ImmutableSet<Net> nets;
     private final @Nullable Team owner;
 
@@ -110,6 +113,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
         private BannerInfo(Location location, BannerMeta meta, ItemStack item, AngleProvider yawProvider) {
             this.location = location;
             this.meta = meta;
+            FLAG_ITEM.set(this.meta, true);
             this.item = item;
             this.yawProvider = yawProvider;
         }
@@ -483,9 +487,13 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
         }
     }
 
+    private boolean isFlagItem(ItemStack item) {
+        return FLAG_ITEM.get(item);
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     private void onPlayerDeath(PlayerDeathEvent event) {
-        event.getDrops().removeIf(itemStack -> itemStack.isSimilar(this.getBannerItem()));
+        event.getDrops().removeIf(this::isFlagItem);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
### Issue
Currently banners (flags) are always dropped when a player dies whilst carrying it. 
This litters the map with fake flags and could cause confusion for new players.

### Reason
Drops are checked against the banner item using the `isSimilar` method.

This method checks that the following are equal:

|        method       |     getBannerItem result    |        itemStack result        |
|:-------------------:|:---------------------------:|:------------------------------:|
|           getTypeID == |             true            |              true              |
|       getDurability == |              0              |       (banner datavalue)       |
|         hasItemMeta |             true            |              true              |
| equals(getItemMeta) | banner meta with base color | banner meta without base color |

Above is the current output of these tests with the correct items failing in both the `getDurability ` and `equals(getItemMeta)` checks. Through painful testing I've found that this is due to the itemStack having a durability (which is the data value) and the banner having none, the meta comparison fails due to the lack of a `base-color` tag within the itemStack (which the banner has).

### Resolution
This pull request resolves the above by using a `BooleanItemTag` over checking just similarities in the meta. This will mean that only flag banners will be removed and similar patterned banners will not. The tag is added at instantiation and checked on player death. 

### Testing
Tested using local a PGM server and the two maps `Concourse` (with building allowed after crafting custom banners) and `Palace CTF` a two flag map.

Not dabbled with Java in a long time and these lambda thingamabobs are new to me so more than welcome for pointers.
   