### PR TITLE
Prevent empty buttons from refreshing the inventory.

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/listeners/InterfaceListener.java
+++ b/PGM/src/main/java/tc/oc/pgm/listeners/InterfaceListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import tc.oc.commons.bukkit.gui.buttons.Button;
+import tc.oc.commons.bukkit.gui.buttons.empty.EmptyButton;
 import tc.oc.commons.core.plugin.PluginFacet;
 import tc.oc.pgm.events.ObserverInteractEvent;
 
@@ -48,7 +49,7 @@ public class InterfaceListener implements Listener, PluginFacet {
         if (gui != null) {
             event.setCancelled(true);
             for (Button button : InterfaceManager.getButtons(gui, event.getRawSlot())) {
-                if (button != null) {
+                if (button != null && !(button instanceof EmptyButton)) {
                     button.function(player);
                     player.updateInventory();
                 }


### PR DESCRIPTION
Empty buttons are added automatically as padding and spacers for the following interfaces `ChestPageInterface`, `SinglePageInterface` and `ChestOptionsPageInterface`.

These slots (although visually empty) do trigger an event on click causing the whole inventory to refresh along with the visual lowering and raising of the arm, this makes it a bit confusing as something visibly happens but there's no feedback on what it was as it wasn't really supposed to.

This can be seen on all of the `Settings` and setting type pages (in the menu book) as these use the page interfaces mentioned above .

This change does not allow an `EmptyButton` to fire a `function` or `updateInventory`.
