### PR TITLE
Improve Death Messages for Void-Related Casualties

### DIFF
--- a/Commons/core/src/main/i18n/templates/pgm/PGMDeath.properties
+++ b/Commons/core/src/main/i18n/templates/pgm/PGMDeath.properties
@@ -92,100 +92,100 @@ death.fall.ground.tripped = {0} tripped and fell
 death.fall.ground.orbit.distance = {0} fell out of a {4} block orbit
 
 death.fall.lava = {0} fell into lava
-death.fall.void = {0} fell out of the world
+death.fall.void = {0} descended into the void
 
 death.fall.ground.melee.mob = {0} was knocked off a high place by a {3}
 death.fall.lava.melee.mob = {0} was knocked into lava by a {3}
-death.fall.void.melee.mob = {0} was knocked out of the world by a {3}
+death.fall.void.melee.mob = {0} was knocked into the void by a {3}
 
 death.fall.ground.melee.player = {0} was punched off a high place by {1}
 death.fall.lava.melee.player = {0} was punched into lava by {1}
-death.fall.void.melee.player = {0} was punched out of the world by {1}
+death.fall.void.melee.player = {0} was punched into the void by {1}
 
 death.fall.ground.melee.player.item = {0} was knocked off a high place by {1}'s {2}
 death.fall.lava.melee.player.item = {0} was knocked into lava by {1}'s {2}
-death.fall.void.melee.player.item = {0} was knocked out of the world by {1}'s {2}
+death.fall.void.melee.player.item = {0} paid a visit to the void courtesy of {1}'s {2}
 
 death.fall.ground.melee.player.mob = {0} was knocked off a high place by {1}'s {3}
 death.fall.lava.melee.player.mob = {0} was knocked into lava by {1}'s {3}
-death.fall.void.melee.player.mob = {0} was knocked out of the world by {1}'s {3}
+death.fall.void.melee.player.mob = {0} was knocked into the void by {1}'s {3}
 
 death.fall.ground.projectile = {0} was shot off a high place by a stray arrow
 death.fall.lava.projectile = {0} was shot into lava by a stray arrow
-death.fall.void.projectile = {0} was shot out of the world by a stray arrow
+death.fall.void.projectile = {0} was shot into the void by a stray arrow
 
 death.fall.ground.projectile.entity = {0} was shot off a high place by a stray {2}
 death.fall.lava.projectile.entity = {0} was shot into lava by a stray {2}
-death.fall.void.projectile.entity = {0} was shot out of the world by a stray {2}
+death.fall.void.projectile.entity = {0} was shot into the void by a stray {2}
 
 death.fall.ground.projectile.mob = {0} was shot off a high place by a {3}
 death.fall.lava.projectile.mob = {0} was shot into lava by a {3}
-death.fall.void.projectile.mob = {0} was shot out of the world by a {3}
+death.fall.void.projectile.mob = {0} was shot into the void by a {3}
 
 death.fall.ground.projectile.mob.entity = {0} was shot off a high place by a {2} from a {3}
 death.fall.lava.projectile.mob.entity = {0} was shot into lava by a {2} from a {3}
-death.fall.void.projectile.mob.entity = {0} was shot out of the world by a {2} from a {3}
+death.fall.void.projectile.mob.entity = {0} was shot into the void by a {2} from a {3}
 
 death.fall.ground.projectile.player.distance = {0} was shot off a high place by {1} from {4} blocks
 death.fall.lava.projectile.player.distance = {0} was shot into lava by {1} from {4} blocks
-death.fall.void.projectile.player.distance = {0} was shot out of the world by {1} from {4} blocks
+death.fall.void.projectile.player.distance = {0} was shot into the void by {1} from {4} blocks
 
 death.fall.ground.projectile.player.distance.snipe = {0} was sniped off a high place by {1} from {4} blocks
 death.fall.lava.projectile.player.distance.snipe = {0} was sniped into lava by {1} from {4} blocks
-death.fall.void.projectile.player.distance.snipe = {0} was sniped out of the world by {1} from {4} blocks
+death.fall.void.projectile.player.distance.snipe = {0} was sniped into the void by {1} from {4} blocks
 
 death.fall.ground.projectile.player.entity.distance = {0} was shot off a high place by {1} with a {2} from {4} blocks
 death.fall.lava.projectile.player.entity.distance = {0} was shot into lava by {1} with a {2} from {4} blocks
-death.fall.void.projectile.player.entity.distance = {0} was shot out of the world by {1} with a {2} from {4} blocks
+death.fall.void.projectile.player.entity.distance = {0} was shot into the void by {1} with a {2} from {4} blocks
 
 death.fall.ground.projectile.player.entity.distance.snipe = {0} was sniped off a high place by {1} with a {2} from {4} blocks
 death.fall.lava.projectile.player.entity.distance.snipe = {0} was sniped into lava by {1} with a {2} from {4} blocks
-death.fall.void.projectile.player.entity.distance.snipe = {0} was sniped out of the world by {1} with a {2} from {4} blocks
+death.fall.void.projectile.player.entity.distance.snipe = {0} was sniped into the void by {1} with a {2} from {4} blocks
 
 death.fall.ground.projectile.player.mob = {0} was shot off a high place by {1}'s {3}
 death.fall.lava.projectile.player.mob = {0} was shot into lava by {1}'s {3}
-death.fall.void.projectile.player.mob = {0} was shot out of the world by {1}'s {3}
+death.fall.void.projectile.player.mob = {0} was shot into the void by {1}'s {3}
 
 death.fall.ground.projectile.player.mob.entity = {0} was shot off a high place by a {2} from {1}'s {3}
 death.fall.lava.projectile.player.mob.entity = {0} was shot into lava by a {2} from {1}'s {3}
-death.fall.void.projectile.player.mob.entity = {0} was shot out of the world by a {2} from {1}'s {3}
+death.fall.void.projectile.player.mob.entity = {0} was shot into the void by a {2} from {1}'s {3}
 
 death.fall.ground.explosive = {0} was blown off a high place
 death.fall.lava.explosive = {0} was blown into lava
-death.fall.void.explosive = {0} was blown out of the world
+death.fall.void.explosive = {0} was blown into the void
 
 death.fall.ground.explosive.player = {0} was blown off a high place by {1}
 death.fall.lava.explosive.player = {0} was blown into lava by {1}
-death.fall.void.explosive.player = {0} was blown out of the world by {1}
+death.fall.void.explosive.player = {0} was blown into the void by {1}
 
 death.fall.ground.explosive.player.entity = {0} was blown off a high place by {1}'s {2}
 death.fall.lava.explosive.player.entity = {0} was blown into lava by {1}'s {2}
-death.fall.void.explosive.player.entity = {0} was blown out of the world by {1}'s {2}
+death.fall.void.explosive.player.entity = {0} was blown into the void by {1}'s {2}
 
 death.fall.ground.explosive.player.entity.distance = {0} was blown off a high place by {1}'s {2} from {4} blocks
 death.fall.lava.explosive.player.entity.distance = {0} was blown into lava by {1}'s {2} from {4} blocks
-death.fall.void.explosive.player.entity.distance = {0} was blown out of the world by {1}'s {2} from {4} blocks
+death.fall.void.explosive.player.entity.distance = {0} was blown into the void by {1}'s {2} from {4} blocks
 
 death.fall.ground.explosive.player.mob = {0} was blown off a high place by {1}'s {3}
 death.fall.lava.explosive.player.mob = {0} was blown into lava by {1}'s {3}
-death.fall.void.explosive.player.mob = {0} was blown out of the world by {1}'s {3}
+death.fall.void.explosive.player.mob = {0} was blown into the void by {1}'s {3}
 
 death.fall.ground.spleef.player = {0} was spleefed off a high place by {1}
 death.fall.lava.spleef.player = {0} was spleefed into lava by {1}
-death.fall.void.spleef.player = {0} was spleefed out of the world by {1}
+death.fall.void.spleef.player = {0} was spleefed into the void by {1}
 
 death.fall.ground.spleef.explosive = {0} was spleefed off a high place by {2}
 death.fall.lava.spleef.explosive = {0} was spleefed into lava by {2}
-death.fall.void.spleef.explosive = {0} was spleefed out of the world by {2}
+death.fall.void.spleef.explosive = {0} was spleefed into the void by {2}
 
 death.fall.ground.spleef.explosive.player = {0} was spleefed off a high place by {1}'s {2}
 death.fall.lava.spleef.explosive.player = {0} was spleefed into lava by {1}'s {2}
-death.fall.void.spleef.explosive.player = {0} was spleefed out of the world by {1}'s {2}
+death.fall.void.spleef.explosive.player = {0} was spleefed into the void by {1}'s {2}
 
 death.fall.ground.spleef.explosive.player.distance = {0} was spleefed off a high place by {1}'s {2} from {4} blocks
 death.fall.lava.spleef.explosive.player.distance = {0} was spleefed into lava by {1}'s {2} from {4} blocks
-death.fall.void.spleef.explosive.player.distance = {0} was spleefed out of the world by {1}'s {2} from {4} blocks
+death.fall.void.spleef.explosive.player.distance = {0} was spleefed into the void by {1}'s {2} from {4} blocks
 
 death.fall.ground.spleef.explosive.player.mob = {0} was spleefed off a high place by {1}'s {3}
 death.fall.lava.spleef.explosive.player.mob = {0} was spleefed into lava by {1}'s {3}
-death.fall.void.spleef.explosive.player.mob = {0} was spleefed out of the world by {1}'s {3}
+death.fall.void.spleef.explosive.player.mob = {0} was spleefed into the void by {1}'s {3}


### PR DESCRIPTION
I changed the death messages triggered by all deaths in the void. I think they're better when they mention the void — more ominous. "Fell out of the world" is nice, but it sounds less serious.