### PR TITLE
Change required players in game for MVP from 10 to 8.

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/highlights/HighlightListener.java
+++ b/PGM/src/main/java/tc/oc/pgm/highlights/HighlightListener.java
@@ -33,7 +33,7 @@ public class HighlightListener implements Listener {
             MatchPlayer bestPlayer = null;
             double bestPlayerPoints = 0;
 
-            if (event.getMatch().getParticipatingPlayers().size() < 10) {
+            if (event.getMatch().getParticipatingPlayers().size() < 8) {
                 return;
             }
 


### PR DESCRIPTION
This is mainly to make it so that if someone leaves a Stratus Ranked game before MVP has been annouced it still sends it for MVP scoring reasons.