### PR TITLE
Make dynamic rotations more aggressive

### DIFF
--- a/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
+++ b/PGM/src/main/java/tc/oc/pgm/rotation/DynamicRotationListener.java
@@ -47,7 +47,7 @@ public class DynamicRotationListener implements PluginFacet, Listener {
         // If a mutation was set for the next map, don't change it yet.
         if (!mutationQueue.isEmpty()) return;
 
-        int playerCount = players.count() - Math.round(event.getMatch().getObservingPlayers().size() / 2);
+        int playerCount = players.count() - Math.round(event.getMatch().getObservingPlayers().size() / 4);
 
         // Get appropriate rotation
         RotationProviderInfo rotation = rotationManager.getProviders().stream()


### PR DESCRIPTION
People have been complaining recently that the rotations aren't changing size aggressively enough. This change increases the contribution that the number of observers has on when we switch to the next rotation and I believe it more accurately reflects the number of people on a server who would like to play.