### PR TITLE
Check punishment type when deciding /l visibility

### DIFF
--- a/Commons/bukkit/src/main/java/tc/oc/commons/bukkit/punishment/PunishmentEnforcer.java
+++ b/Commons/bukkit/src/main/java/tc/oc/commons/bukkit/punishment/PunishmentEnforcer.java
@@ -171,7 +171,7 @@ public class PunishmentEnforcer implements Enableable, MessageListener {
     }
 
     private boolean viewByLookup(CommandSender sender, Punishment punishment) {
-        return sender.hasPermission(punishment.stale() ? LOOK_UP_STALE : LOOK_UP);
+        return sender.hasPermission(punishment.stale() ? LOOK_UP_STALE : LOOK_UP) && viewByType(sender, punishment);
     }
 
     private boolean viewBySilent(CommandSender sender, Punishment punishment) {


### PR DESCRIPTION
When doing /l to view a player's punishments, no check is currently performed on the punishment type when determining visibility. This allows players to view punishments they shouldn't be able to (such as warnings).

Note that this has the side effect of preventing you from seeing your own warnings with /l, which is supposed to have its own permission node, but it's better than allowing others' warnings to be seen and can be added on afterwards if required.