### PR TITLE
Use Commons translation strings for menu interface stats

### DIFF
--- a/Commons/core/src/main/i18n/templates/pgm/PGMUI.properties
+++ b/Commons/core/src/main/i18n/templates/pgm/PGMUI.properties
@@ -346,13 +346,3 @@ broadcast.alliancesNotAllowed = Creating alliances with other players is NOT all
 
 countdown.chestsRefill = Chests will refill in {0}
 countdown.glowingEffect = Glowing effect in {0}
-
-stats.ui.list = 's Stats
-stats.ui.kills = Kills:
-stats.ui.deaths = Deaths:
-stats.ui.kd = KD:
-stats.ui.kk = KK:
-stats.ui.wools = Wools Placed:
-stats.ui.cores = Cores Leaked:
-stats.ui.monuments = Monuments Destroyed:
-stats.ui.teamkills = TK:

--- a/PGM/src/main/java/tc/oc/pgm/menu/gui/MainMenuInterface.java
+++ b/PGM/src/main/java/tc/oc/pgm/menu/gui/MainMenuInterface.java
@@ -6,12 +6,12 @@ import org.bukkit.entity.Player;
 import tc.oc.commons.bukkit.chat.PlayerComponent;
 import tc.oc.commons.bukkit.gui.buttons.Button;
 import tc.oc.commons.bukkit.gui.interfaces.ChestInterface;
+import tc.oc.commons.bukkit.localization.CommonsTranslations;
 import tc.oc.commons.bukkit.stats.StatsUtil;
 import tc.oc.commons.bukkit.tokens.TokenUtil;
 import tc.oc.commons.bukkit.util.Constants;
 import tc.oc.commons.bukkit.util.ItemCreator;
 import tc.oc.commons.core.chat.Component;
-import tc.oc.pgm.PGMTranslations;
 import tc.oc.pgm.tokens.gui.MainTokenButton;
 import tc.oc.pgm.tokens.gui.MutationTokenInterface;
 import tc.oc.pgm.tokens.gui.TokenPurchaseInterface;
@@ -41,13 +41,13 @@ public class MainMenuInterface extends ChestInterface {
         buttons.add(new Button(
                 new ItemCreator(Material.GOLDEN_APPLE)
                         .setData(1)
-                        .setName(Constants.PREFIX + getPlayer().getDisplayName() + PGMTranslations.get().t("stats.ui.list", getPlayer()))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.kills", getPlayer()) + ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("kills")))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.deaths", getPlayer()) + ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("deaths")))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.kd", getPlayer()) + ChatColor.BLUE + String.format("%.2f", stats.get("kd")))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.wools", getPlayer()) + ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("wool_placed")))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.cores", getPlayer()) + ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("cores_leaked")))
-                        .addLore(ChatColor.AQUA + PGMTranslations.get().t("stats.ui.monuments", getPlayer()) + ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("destroyables_destroyed")))
+                        .setName(CommonsTranslations.get().t("stats.list", getPlayer(), Constants.PREFIX + getPlayer().getDisplayName()))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.kills", getPlayer(), ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("kills"))))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.deaths", getPlayer(), ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("deaths"))))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.kd", getPlayer(), ChatColor.BLUE + String.format("%.2f", stats.get("kd"))))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.wools", getPlayer(), ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("wool_placed"))))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.cores", getPlayer(), ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("cores_leaked"))))
+                        .addLore(ChatColor.AQUA + CommonsTranslations.get().t("stats.monuments", getPlayer(), ChatColor.BLUE + String.format("%,d", (int)(double)stats.get("destroyables_destroyed"))))
                 , 13));
 
         buttons.add(new Button(


### PR DESCRIPTION
Translate the stats menu components using the existing Commons translations.
This also fixes the lack of a space after the colon as the translations come with them already.

Before and after... (no rank or stats on localhost hence the difference).

![image](https://user-images.githubusercontent.com/8608892/64078830-b9dfd600-ccd7-11e9-8b51-697fa267aa1a.png)

This also removes the PGM versions of the translations previously references as these are not used elsewhere.